### PR TITLE
pcl_test: Fix memset calls

### DIFF
--- a/test/persistence_client_library_test_file.c
+++ b/test/persistence_client_library_test_file.c
@@ -540,11 +540,11 @@ START_TEST(test_DataFileBackupCreation)
 
    rval = pclFileReadData(fd_RW, rBuffer, 10);
    fail_unless(rval == 10, "Failed read 10 bytes");
-   memset(rBuffer, 0, 1024);
+   memset(rBuffer, 0, 1024 * sizeof(char));
 
    rval = pclFileReadData(fd_RW, rBuffer, 15);
    fail_unless(rval == 15, "Failed read 15 bytes");
-   memset(rBuffer, 0, 1024);
+   memset(rBuffer, 0, 1024 * sizeof(char));
 
    rval = pclFileReadData(fd_RW, rBuffer, 20);
    fail_unless(rval == 20, "Failed read 20 bytes");
@@ -727,11 +727,11 @@ START_TEST(test_DataHandle)
       char fileNameBuf[1024] = {0};
       int i = 0, size = 0;
 
-      memset(handleArray, -1, 1024);
+      memset(handleArray, -1, 1024 * sizeof(int));
 
       for(i=0; i<512; i++)
       {
-         memset(fileNameBuf,0,1024);
+         memset(fileNameBuf,0,1024 * sizeof(char));
          snprintf(fileNameBuf, 1024, "media/threeAnotherFileTestData.db_%d", i);
          //printf("\n\nOpen - %d\n", i);
          handleArray[i] = pclFileOpen(PCL_LDBID_LOCAL, fileNameBuf, 4, 77);
@@ -742,7 +742,7 @@ START_TEST(test_DataHandle)
       {
          if(handleArray[i] >=0 )
          {
-            memset(writeBuffer,0,256);
+            memset(writeBuffer,0, 256 * sizeof(char));
             snprintf(writeBuffer, 256, "START_TEST(test_DataHandle)_media/some_test_data_to_show_read and write is working_%d", i);
 
             pclFileSeek(handleArray[i], 0, SEEK_SET);
@@ -757,7 +757,7 @@ START_TEST(test_DataHandle)
          if(handleArray[i] >=0 )
          {
             memset(buffer,     0, READ_SIZE);
-            memset(writeBuffer,0, 256);
+            memset(writeBuffer,0, 256 * sizeof(char));
             snprintf(writeBuffer, 256, "START_TEST(test_DataHandle)_media/some_test_data_to_show_read and write is working_%d", i);
             pclFileSeek(handleArray[i], 0, SEEK_SET);
             size = pclFileReadData(handleArray[i], buffer, READ_SIZE);
@@ -846,7 +846,7 @@ void do_shutdown_sequence(int shutdownReg, unsigned int numOfFiles)
 
    for(i=0; i<numOfFiles; i++)
    {
-     memset(fileNameBuf,0,1024);
+     memset(fileNameBuf, 0, 1024 * sizeof(char));
      snprintf(fileNameBuf, 1024, "media/threeAnotherFileTestData.db_%d", i);
      handleArray[i] = pclFileOpen(PCL_LDBID_LOCAL, fileNameBuf, 4, 12);
    }
@@ -856,7 +856,7 @@ void do_shutdown_sequence(int shutdownReg, unsigned int numOfFiles)
    {
       if(handleArray[i] >=0 )
       {
-         memset(writeBuffer,0,1024);
+         memset(writeBuffer, 0, 1024 * sizeof(char));
          snprintf(writeBuffer, 1024, "START_TEST(test_DataHandle)_media/some_test_data_to_show_read and write is working_%d_%s", i, gWriteBuffer);
 
          pclFileSeek(handleArray[i], 0, SEEK_SET);
@@ -1141,7 +1141,7 @@ void* fileWriteThread(void* userData)
          rsize = pclFileReadData(threadData->fd1, readbuffer, (int)bufferSize);
          ck_assert_int_eq(rsize, (int)bufferSize);
 
-         memset(keyBuffer, 0, 1024);
+         memset(keyBuffer, 0, 1024 * sizeof(unsigned char));
          ret = pclKeyReadData(PCL_LDBID_LOCAL, "pos/last_position",  1, 1, keyBuffer, 1024);
          ck_assert_str_eq( (char*)keyBuffer, "CACHE_ +48 10' 38.95, +8 44' 39.06");
          ck_assert_int_eq( ret,  (int)strlen("CACHE_ +48 10' 38.95, +8 44' 39.06") );
@@ -1150,7 +1150,7 @@ void* fileWriteThread(void* userData)
          rsize2 = pclFileReadData(threadData->fd2, readbuffer2, (int)bufferSize2);
          ck_assert_int_eq(rsize2, (int)bufferSize2);
 
-         memset(keyBuffer, 0, 1024);
+         memset(keyBuffer, 0, 1024 * sizeof(unsigned char));
          ret = pclKeyReadData(0x20, "address/home_address",      4, 0, keyBuffer, READ_SIZE);
          ck_assert_str_eq( (char*)keyBuffer, "WT_ 55327 Heimatstadt, Wohnstrasse 31");
          ck_assert_int_eq(ret, (int)strlen("WT_ 55327 Heimatstadt, Wohnstrasse 31"));
@@ -1273,15 +1273,15 @@ START_TEST(test_FileBackupAndRecovery)
    fd2 = pclFileOpen(PCL_LDBID_LOCAL, "media/file02.txt", 200, 100);
    fd3 = pclFileOpen(PCL_LDBID_LOCAL, "media/file03.txt", 200, 100);
 
-   memset(readBuffer, 0, 8192);
+   memset(readBuffer, 0, 8192 * sizeof(char));
    sizeRead = pclFileReadData(fd1, readBuffer, 8192);
    fail_unless(sizeRead == strlen(gWriteBuffer), "FailedReadSize 1 => soll:%d - ist: %d\n", strlen(gWriteBuffer), sizeRead);
 
-   memset(readBuffer, 0, 8192);
+   memset(readBuffer, 0, 8192 * sizeof(char));
    sizeRead = pclFileReadData(fd2, readBuffer, 8192);
    fail_unless(sizeRead == strlen(gWriteBuffer2), "FailedReadSize 2 => soll:%d - ist: %d\n", strlen(gWriteBuffer2), sizeRead);
 
-   memset(readBuffer, 0, 8192);
+   memset(readBuffer, 0, 8192 * sizeof(char));
    sizeRead = pclFileReadData(fd3, readBuffer, 8192);
    fail_unless(sizeRead == strlen(gWriteBuffer3), "FailedReadSize 3 => soll:%d - ist: %d\n", strlen(gWriteBuffer3), sizeRead);
 
@@ -1310,8 +1310,8 @@ START_TEST(test_FileBackupAndRecovery)
    //
    // check content of backup and csum
    //
-   memset(readBufferBackup, 0, 8192);
-   memset(readBufferCsum, 0, 256);
+   memset(readBufferBackup, 0, 8192 * sizeof(char));
+   memset(readBufferCsum, 0, 256 * sizeof(char));
 
    fd1b = open(gFile1Backup, O_RDONLY);
    fd1c = open(gFile1Csum, O_RDONLY);
@@ -1329,8 +1329,8 @@ START_TEST(test_FileBackupAndRecovery)
    close(fd1c);
 
    // -----
-   memset(readBufferBackup, 0, 8192);
-   memset(readBufferCsum, 0, 256);
+   memset(readBufferBackup, 0, 8192 * sizeof(char));
+   memset(readBufferCsum, 0, 256 * sizeof(char));
 
    fd2b = open(gFile2Backup, O_RDONLY);
    fd2c = open(gFile2Csum, O_RDONLY);
@@ -1348,8 +1348,8 @@ START_TEST(test_FileBackupAndRecovery)
    close(fd2c);
 
    // -----
-   memset(readBufferBackup, 0, 8192);
-   memset(readBufferCsum, 0, 256);
+   memset(readBufferBackup, 0, 8192 * sizeof(char));
+   memset(readBufferCsum, 0, 256 * sizeof(char));
 
    fd3b = open(gFile3Backup, O_RDONLY);
    fd3c = open(gFile3Csum, O_RDONLY);
@@ -1389,7 +1389,7 @@ START_TEST(test_FileBackupAndRecovery)
    // expected: so keep original
    fd = pclFileOpen(PCL_LDBID_LOCAL, "media/csMismatch.txt", 200, 100);
 
-   memset(readBuffer, 0, 8192);
+   memset(readBuffer, 0, 8192 * sizeof(char));
    sizeRead = pclFileReadData(fd, readBuffer, 8192);
    fail_unless(sizeRead == strlen(gWriteBuffer3), "Failed read=> soll:%d - ist: %d\n", strlen(gWriteBuffer3), sizeRead);
    fail_unless(strncmp((const char*)readBuffer, (const char*)gWriteBuffer3, strlen(gWriteBuffer3)) == 0, "Read data does not match\n");
@@ -1400,7 +1400,7 @@ START_TEST(test_FileBackupAndRecovery)
    // expected: keep original
    fd = pclFileOpen(PCL_LDBID_LOCAL, "media/backMismatch.txt", 200, 100);
 
-   memset(readBuffer, 0, 8192);
+   memset(readBuffer, 0, 8192 * sizeof(char));
    sizeRead = pclFileReadData(fd, readBuffer, 8192);
    fail_unless(sizeRead == strlen(gWriteBuffer3), "Failed read=> soll:%d - ist: %d\n", strlen(gWriteBuffer3), sizeRead);
    fail_unless(strncmp((const char*)readBuffer, (const char*)gWriteBuffer3, strlen(gWriteBuffer3)) == 0, "Read data does not match\n");
@@ -1411,7 +1411,7 @@ START_TEST(test_FileBackupAndRecovery)
    // expected: use content form backup file
    fd = pclFileOpen(PCL_LDBID_LOCAL, "media/csumAndB_ok.txt", 200, 100);
 
-   memset(readBuffer, 0, 8192);
+   memset(readBuffer, 0, 8192 * sizeof(char));
    sizeRead = pclFileReadData(fd, readBuffer, 8192);
    fail_unless(sizeRead == strlen(gWriteBuffer2), "Failed read=> soll:%d - ist: %d\n", strlen(gWriteBuffer2), sizeRead);
    fail_unless(strncmp((const char*)readBuffer, (const char*)gWriteBuffer2, strlen(gWriteBuffer2)) == 0, "Read data does not match\n");
@@ -1422,7 +1422,7 @@ START_TEST(test_FileBackupAndRecovery)
    // expected: keep original
    fd = pclFileOpen(PCL_LDBID_LOCAL, "/media/csum_ok.txt", 200, 100);
 
-   memset(readBuffer, 0, 8192);
+   memset(readBuffer, 0, 8192 * sizeof(char));
    sizeRead = pclFileReadData(fd, readBuffer, 8192);
    fail_unless(sizeRead == strlen(gWriteBuffer2), "Failed read=> soll:%d - ist: %d\n", strlen(gWriteBuffer2), sizeRead);
    fail_unless(strncmp((const char*)readBuffer, (const char*)gWriteBuffer2, strlen(gWriteBuffer2)) == 0, "Read data does not match\n");
@@ -1433,7 +1433,7 @@ START_TEST(test_FileBackupAndRecovery)
    // expected: no recovery possible, return error code
    fd = pclFileOpen(PCL_LDBID_LOCAL, "/media/csum_nok.txt", 200, 100);
 
-   memset(readBuffer, 0, 8192);
+   memset(readBuffer, 0, 8192 * sizeof(char));
    sizeRead = pclFileReadData(fd, readBuffer, 8192);
    fail_unless(sizeRead <= EPERS_COMMON, "Read succeeded, but should not => return: %dn", sizeRead);
    pclFileClose(fd);
@@ -1442,7 +1442,7 @@ START_TEST(test_FileBackupAndRecovery)
    // only backup file available, matches original data
    // expected: keep original
    fd = pclFileOpen(PCL_LDBID_LOCAL, "/media/back_ok.txt", 200, 100);
-   memset(readBuffer, 0, 8192);
+   memset(readBuffer, 0, 8192 * sizeof(char));
    sizeRead = pclFileReadData(fd, readBuffer, 8192);
    fail_unless(sizeRead == strlen(gWriteBuffer), "Failed read=> soll:%d - ist: %d\n", strlen(gWriteBuffer), sizeRead);
    fail_unless(strncmp((const char*)readBuffer, (const char*)gWriteBuffer, strlen(gWriteBuffer)) == 0, "Read data does not match\n");
@@ -1453,7 +1453,7 @@ START_TEST(test_FileBackupAndRecovery)
    // expected: no recovery possible, return error code
    fd = pclFileOpen(PCL_LDBID_LOCAL, "/media/back_nok.txt", 200, 100);
 
-   memset(readBuffer, 0, 8192);
+   memset(readBuffer, 0, 8192 * sizeof(char));
    sizeRead = pclFileReadData(fd, readBuffer, 8192);
    fail_unless(sizeRead <= EPERS_COMMON, "Read succeeded, but should not => return: %dn", sizeRead);
    pclFileClose(fd);
@@ -1606,7 +1606,7 @@ void* WriteOneThread(void* userData)
 
    for(i=0; i<NUM_OF_OPEN_FILES; i++)
    {
-      memset(fileBuffer,0,1024);
+      memset(fileBuffer,0,1024 * sizeof(char));
       snprintf(fileBuffer, 1024, "media/oneAnotherFileTestData.db_%d", i);
       printf("One open: %d\n", i);
       fda[i] = pclFileOpen(PCL_LDBID_LOCAL, fileBuffer, 4, 4);
@@ -1624,7 +1624,7 @@ void* WriteOneThread(void* userData)
 
       memset(readbuffer, 0, bufferSize);
       memset(readbuffer2, 0, bufferSize2);
-      memset(keyBuffer, 0, 1024);
+      memset(keyBuffer, 0, 1024 * sizeof(unsigned char));
 
       if(i%2)
       {
@@ -1638,7 +1638,7 @@ void* WriteOneThread(void* userData)
          for(j=0; j< NUM_OF_OPEN_FILES; j++)
          {
             memset(readbuffer, 0, bufferSize);
-            memset(writeBuffer,0,128);
+            memset(writeBuffer,0,128 * sizeof(char));
             snprintf(writeBuffer, 128, "%s_media/oneAnotherFileTestData.db_%d", (const char*)userData, j);
             pclFileSeek(fda[j], 0, SEEK_SET);
             size2 = pclFileReadData(fda[j], readbuffer, (int)bufferSize);
@@ -1665,7 +1665,7 @@ void* WriteOneThread(void* userData)
          printf("Wa\n");
          for(j=0; j< NUM_OF_OPEN_FILES; j++)
          {
-            memset(writeBuffer,0,128);
+            memset(writeBuffer,0,128 * sizeof(char));
             snprintf(writeBuffer, 128, "%s_media/oneAnotherFileTestData.db_%d", (const char*)userData, j);
             pclFileSeek(fda[j], 0, SEEK_SET);
             size2 = pclFileWriteData(fda[j], writeBuffer, (int)strlen(writeBuffer));
@@ -1688,7 +1688,7 @@ void* WriteOneThread(void* userData)
          pclFileSeek(fd2, 0, SEEK_SET);
       }
 
-      memset(keyBuffer, 0, 1024);
+      memset(keyBuffer, 0, 1024 * sizeof(unsigned char));
       ret = pclKeyReadData(0x20, "address/home_address",      4, 0, keyBuffer, READ_SIZE);
       if( ret < 0)
          printf("Failed\n");
@@ -1743,7 +1743,7 @@ void* WriteThreeThread(void* userData)
 
    for(i=0; i<NUM_OF_OPEN_FILES; i++)
    {
-      memset(fileBuffer,0,1024);
+      memset(fileBuffer,0,1024 * sizeof(char));
       snprintf(fileBuffer, 1024, "media/threeAnotherFileTestData.db_%d", i);
       printf("Three open: %d\n", i);
       fda[i] = pclFileOpen(PCL_LDBID_LOCAL, fileBuffer, 5, 5);
@@ -1762,7 +1762,7 @@ void* WriteThreeThread(void* userData)
 
       memset(readbuffer, 0, bufferSize);
       memset(readbuffer2, 0, bufferSize2);
-      memset(keyBuffer, 0, 1024);
+      memset(keyBuffer, 0, 1024 * sizeof(char));
 
       if(i%2)
       {
@@ -1776,7 +1776,7 @@ void* WriteThreeThread(void* userData)
          for(j=0; j< NUM_OF_OPEN_FILES; j++)
          {
             memset(readbuffer, 0, bufferSize);
-            memset(writeBuffer,0,128);
+            memset(writeBuffer, 0, 128 * sizeof(char));
             snprintf(writeBuffer, 128, "%s_media/oneAnotherFileTestData.db_%d", (const char*)userData, j);
             pclFileSeek(fda[j], 0, SEEK_SET);
             size2 = pclFileReadData(fda[j], readbuffer, (int)bufferSize);
@@ -1803,7 +1803,7 @@ void* WriteThreeThread(void* userData)
          printf("Wa\n");
          for(j=0; j< NUM_OF_OPEN_FILES; j++)
          {
-            memset(writeBuffer,0,128);
+            memset(writeBuffer, 0, 128 * sizeof(char));
             snprintf(writeBuffer, 128, "%s_media/oneAnotherFileTestData.db_%d", (const char*)userData, j);
             pclFileSeek(fda[j], 0, SEEK_SET);
             size2 = pclFileWriteData(fda[j], writeBuffer, (int)strlen(writeBuffer));
@@ -1827,7 +1827,7 @@ void* WriteThreeThread(void* userData)
          pclFileSeek(fd2, 0, SEEK_SET);
       }
 
-      memset(keyBuffer, 0, 1024);
+      memset(keyBuffer, 0, 1024 * sizeof(unsigned char));
       ret = pclKeyReadData(0x20, "address/home_address",      4, 0, keyBuffer, READ_SIZE);
       if( ret < 0)
          printf("Failed\n");
@@ -1884,7 +1884,7 @@ void* WriteTwoThread(void* userData)
    {
       memset(readbuffer, 0, bufferSize);
       memset(readbuffer2, 0, bufferSize2);
-      memset(keyBuffer, 0, 1024);
+      memset(keyBuffer, 0, 1024 * sizeof(unsigned char));
 
       printf("loop Two: %d\n", i);
       if(i%2)
@@ -1923,7 +1923,7 @@ void* WriteTwoThread(void* userData)
             (unsigned char*)"WT_ /var/opt/user_manual_climateControl.pdf", strlen("WT_ /var/opt/user_manual_climateControl.pdf"));
 
 
-      memset(keyBuffer, 0, 1024);
+      memset(keyBuffer, 0, 1024 * sizeof(unsigned char));
       ret = pclKeyReadData(PCL_LDBID_LOCAL, "pos/last_position",  1, 1, keyBuffer, 1024);
       if( ret < 0)
          printf("Failed\n");


### PR DESCRIPTION
The length parameter was improperly initialized writing only partially to
some of the memset target variables. This caused build errors with newer
gcc versions.

Signed-off-by: Oscar Andreasson <oscar.andreasson@pelagicore.com>