### PR TITLE
persistence_client_library_benchmark.c: fix long compilations on 32-bit cpus

### DIFF
--- a/test/persistence_client_library_benchmark.c
+++ b/test/persistence_client_library_benchmark.c
@@ -167,7 +167,7 @@ void read_benchmark(int numLoops)
 void write_benchmark(int numLoops)
 {
    int ret = 0, i = 0;
-   long duration = 0,  size = 0;
+   long long duration = 0,  size = 0;
    struct timespec readStart, readEnd;
    char key[128] = { 0 };
    unsigned char buffer[7168] = {0};   // 7kB


### PR DESCRIPTION
Fix compilation on 32-bit cpu's, long long and long are different datatypes
on 32-bit but not 64-bit cpu's.

Signed-off-by: Oscar Andreasson <oscar.andreasson@pelagicore.com>