### PR TITLE
Fix compilation with GCC 8

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,7 +30,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 
 # Overwrite the build in defaults
-CFLAGS="-Wall -O -Werror -fstack-protector -pthread -Wformat -Wformat-security -fexceptions -fstrict-aliasing -fno-omit-frame-pointer -Wconversion -D_FORTIFY_SOURCE=2"
+CFLAGS="-Wall -O -Werror -fstack-protector -pthread -Wformat -Wformat-security -fexceptions -fstrict-aliasing -fno-omit-frame-pointer -Wconversion -D_FORTIFY_SOURCE=2 -Wno-format-truncation"
 
 # Checks for programs.
 AC_PROG_CC


### PR DESCRIPTION
GCC 8 is much more strict when it comes to strings formatting and produces the following errors:

```
| persistence_client_library_file.c:1100:62: error: '%s' directive output may be truncated writing 24 bytes into a region of size between 1 and 255 [-Werror=format-truncation=]
|   snprintf(defaultPath, PERS_ORG_MAX_LENGTH_PATH_FILENAME, "%s%s/%s", pathPrefix, PERS_ORG_CONFIG_DEFAULT_DATA_FOLDER_NAME_, resource_id);
|                                                               ^~
| In file included from /home/sashko/work/manifest/build/tmp/work/corei7-64-pelux-linux/persistence-client-library/1.1.0+gitAUTOINC+140cb9c7db-r5/recipe-sysroot/usr/include/stdio.h:873,
|                  from persistence_client_library_tree_helper.h:23,
|                  from persistence_client_library_backup_filelist.h:23,
|                  from persistence_client_library_file.c:21:
| /home/sashko/work/manifest/build/tmp/work/corei7-64-pelux-linux/persistence-client-library/1.1.0+gitAUTOINC+140cb9c7db-r5/recipe-sysroot/usr/include/bits/stdio2.h:67:10: note: '__builtin___snprintf_chk' output 26 or more bytes (assuming 280) into a destination of size 255
|    return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
|           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
|         __bos (__s), __fmt, __va_arg_pack ());
|         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
| persistence_client_library_file.c:1104:67: error: '%s' directive output may be truncated writing 12 bytes into a region of size between 1 and 255 [-Werror=format-truncation=]
|        snprintf(defaultPath, PERS_ORG_MAX_LENGTH_PATH_FILENAME, "%s%s/%s", pathPrefix, PERS_ORG_DEFAULT_DATA_FOLDER_NAME_, resource_id);
|                                                                    ^~
```

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>